### PR TITLE
fix: pin setup-gcloud to SHA with valid action.yml

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # v1
 
     - name: Setup python environment
-      uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de  # v1
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
           python-version: 3.7
 

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup gcloud CLI
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
       with:
-        version: '270.0.0'
+        version: '569.0.0'
         service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
 

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     name: Deploy to demo environment

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.7
 
     - name: Setup gcloud CLI
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@01af06c41d9aa0790d6fdc8f0b982b768ca4d102  # master
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -34,7 +34,7 @@ jobs:
       run: docker build . -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:demo_latest -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:$GITHUB_SHA
 
     - name: Publish docker image to Google Cloud
-      run: docker -- push eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
+      run: docker push --all-tags eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
 
     - name: Apply Helm template
       uses: stefanprodan/kube-tools@0d241188296aee8e513e9597ba7eede46f6155ef  # v1.7.2

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -21,12 +21,13 @@ jobs:
       with:
           python-version: '3.12'
 
-    - name: Setup gcloud CLI
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
       with:
-        version: '569.0.0'
-        service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
-        service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+        credentials_json: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+
+    - name: Setup gcloud CLI
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
     - run: gcloud auth configure-docker
 

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup python environment
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-          python-version: 3.7
+          python-version: '3.12'
 
     - name: Setup gcloud CLI
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -34,7 +34,7 @@ jobs:
         run: docker build . -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:latest -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:$GITHUB_SHA
 
       - name: Publish docker image to Google Cloud
-        run: docker -- push eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
+        run: docker push --all-tags eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
 
       - name: Apply Helm template
         uses: stefanprodan/kube-tools@0d241188296aee8e513e9597ba7eede46f6155ef  # v1.7.2

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -21,12 +21,13 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Setup gcloud CLI
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
-          version: '569.0.0'
-          service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+          credentials_json: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
       - run: gcloud auth configure-docker
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     name: Deploy to prod environment

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # v1
 
       - name: Setup python environment
-        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de  # v1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.7
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup python environment
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: 3.7
+          python-version: '3.12'
 
       - name: Setup gcloud CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup gcloud CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
         with:
-          version: '270.0.0'
+          version: '569.0.0'
           service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.7
 
       - name: Setup gcloud CLI
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@01af06c41d9aa0790d6fdc8f0b982b768ca4d102  # master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # v1
 
     - name: Setup python environment
-      uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de  # v1
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
           python-version: 3.7
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup gcloud CLI
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
       with:
-        version: '270.0.0'
+        version: '569.0.0'
         service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.7
 
     - name: Setup gcloud CLI
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@01af06c41d9aa0790d6fdc8f0b982b768ca4d102  # master
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -21,12 +21,13 @@ jobs:
       with:
           python-version: '3.12'
 
-    - name: Setup gcloud CLI
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
       with:
-        version: '569.0.0'
-        service_account_email: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_EMAIL }}
-        service_account_key: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+        credentials_json: ${{ secrets.GCP_SA_DIGDIR_FDK_GCR_KEY }}
+
+    - name: Setup gcloud CLI
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
     - run: gcloud auth configure-docker
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup python environment
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-          python-version: 3.7
+          python-version: '3.12'
 
     - name: Setup gcloud CLI
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@b94035a6aac71cdacf6e682bbbef2e927960f8ac  # master

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     name: Deploy to staging environment

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -34,7 +34,7 @@ jobs:
       run: docker build . -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:staging_latest -t eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl:$GITHUB_SHA
 
     - name: Publish docker image to Google Cloud
-      run: docker -- push eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
+      run: docker push --all-tags eu.gcr.io/digdir-fdk-infra/fdk-dataservice-harvester-etl
 
     - name: Apply Helm template
       uses: stefanprodan/kube-tools@0d241188296aee8e513e9597ba7eede46f6155ef  # v1.7.2


### PR DESCRIPTION
  - Repin `setup-gcloud` to `b94035a6` — the previously pinned SHA on `GoogleCloudPlatform/github-actions` no longer contains `setup-gcloud/action.yml` (cleaned up in
  July 2021)
  - Bump `setup-python` SHA from v1 to v6.2.0 (`a309ff8b`) so it can install Python versions not pre-installed on the runner
  - Bump `python-version` 3.7 → 3.12 (3.7 is EOL and has no Ubuntu 24.04 build in the python-versions manifest)
